### PR TITLE
ls-lint Allow Dynamic Route Files

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -6,7 +6,7 @@ ls:
       .js: PascalCase
       .stories.js: PascalCase
     pages:
-      .js: kebab-case | regex:^_[a-z-.]* #regex for kebab-case with preceeding underscore
+      .js: kebab-case | regex:^_[a-z-.]* | regex:^\[\w*\] #regex for kebab-case with preceeding underscore or [] for dynamic routing
   scripts:
     templates:
       .js: PascalCase


### PR DESCRIPTION
fix: allowing dynamic route files to pass ls lint check