### PR TITLE
Serve Static Files Via Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sitemap-generator": "node scripts/nextjs-sitemap-generator.js",
     "robots-txt-generator": "node scripts/robots-txt-generator.js",
     "\n ######################  Support Development Tools  ######################": "",
-    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook": "start-storybook -p 9001 -c .storybook -s ./public",
     "component": "node scripts/component.js",
     "page": "node scripts/component.js --page",
     "\n ######################  Automation Tools  ######################": "",


### PR DESCRIPTION
Currently it's not possible to access files in `public` folder while using storybook. This PR enables that functionality.

https://storybook.js.org/docs/react/configure/images-and-assets#serving-static-files-via-storybook