### PR TITLE
Fix: Add crossorigin for webmanifest

### DIFF
--- a/public/favicons/html_code.html
+++ b/public/favicons/html_code.html
@@ -1,7 +1,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-<link rel="manifest" href="/favicons/site.webmanifest" crossorigin="use-credentials">
+<link rel="manifest" href="/favicons/site.webmanifest" crossOrigin="use-credentials">
 <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000">
 <link rel="shortcut icon" href="/favicons/favicon.ico">
 <meta name="msapplication-TileColor" content="#ffc40d">

--- a/public/favicons/html_code.html
+++ b/public/favicons/html_code.html
@@ -1,7 +1,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-<link rel="manifest" href="/favicons/site.webmanifest">
+<link rel="manifest" href="/favicons/site.webmanifest" crossorigin="use-credentials">
 <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000">
 <link rel="shortcut icon" href="/favicons/favicon.ico">
 <meta name="msapplication-TileColor" content="#ffc40d">

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -27,7 +27,7 @@ function Head({ title, description, keywords }) {
       <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
-      <link rel="manifest" href="/favicons/site.webmanifest" />
+      <link rel="manifest" href="/favicons/site.webmanifest" crossorigin="use-credentials" />
       <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000" />
       <link rel="shortcut icon" href="/favicons/favicon.ico" />
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -27,7 +27,7 @@ function Head({ title, description, keywords }) {
       <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
-      <link rel="manifest" href="/favicons/site.webmanifest" crossorigin="use-credentials" />
+      <link rel="manifest" href="/favicons/site.webmanifest" crossOrigin="use-credentials" />
       <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000" />
       <link rel="shortcut icon" href="/favicons/favicon.ico" />
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix (non-breaking change which fixes an issue)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Did you test your solution?**
- [ ] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
site.webmanifest returning 401 when behind Basic Auth
<img width="984" alt="Screen Shot 2021-03-21 at 12 19 46 AM" src="https://user-images.githubusercontent.com/5311991/111893751-2c5bf800-89db-11eb-8dad-eb9ba9cca315.png">

## Solution Description
Add crossorigin use-credential even if under same origin as per [MSDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials)

<img width="790" alt="Screen Shot 2021-03-21 at 12 13 40 AM" src="https://user-images.githubusercontent.com/5311991/111893710-eacb4d00-89da-11eb-9cd3-6cf7c6200c98.png">
