### PR TITLE
feature: add skip to content links

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -25,6 +25,9 @@ function Nav() {
     <nav className={classnames(styles.Nav)}>
       <div className={styles.wrapper}>
         <ul className={styles.routes}>
+          <a tabIndex="0" aria-label="Skip to content" className={styles.skipToContent} href="#start-of-content">
+            Skip to content
+          </a>
           {Object.values(routes).map(({ path, title }) => (
             <li key={path}>
               <Link href={path}>
@@ -44,6 +47,7 @@ function Nav() {
           ))}
         </ul>
       </div>
+      <section aria-hidden="true" id="start-of-content"></section>
     </nav>
   );
 }

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -16,6 +16,22 @@
     height: $navbar-height-desktop;
   }
 
+  .skipToContent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: fit-content;
+    pointer-events: none;
+    opacity: 0.0001;
+  }
+
+  .skipToContent:focus,
+  .skipToContent:active {
+    color: $white;
+    background-color: $black;
+    opacity: 1;
+  }
+
   > .wrapper {
     display: flex;
     max-width: px(1440);


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

**Adviser warns of an error with netmask (high).**

Advisory code is 1658: https://www.npmjs.com/advisories/1658**

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Per WCAG 2.1 AA compliance having [bypass blocks](https://www.w3.org/WAI/WCAG21/quickref/#bypass-blocks) on each page is necessary.

## Solution Description

 One notably method of solving this is by:

- [G1: Adding a link at the top of each page that goes directly to the main content area](https://www.w3.org/WAI/WCAG21/Techniques/general/G1.html)

An alternate solution for Jam3 projects would include adding a subnav which satisfies criteria:

- [G124: Adding links at the top of the page to each area of the content](https://www.w3.org/WAI/WCAG21/Techniques/general/G124.html)

---- 

This PR creates a tab-able, screen readable skip to content button which the user can click to skip the navbar on each page. It does so by using an anchor link at the bottom of the nav page to change focus.

**Notable findings:**
- This link **must** be the first targetable focus on each page
- While screen readers should be able to pick up content with `opacity: 0;` [ChromeVox seems to ignore elements with opacity 0](https://github.com/michalsnik/aos/issues/397) all together when a user is navigating with their keyboard. A fix for this is to set the element with `opacity: 0.0001`. While this is not ideal, it guarantees the maximum number of screen readers will be able to read the link while not impacting design. In the future, when this ChromeVox bug is patched, opacity should be adjusted back to 0.

Unfocused link:
<img width="1678" alt="Screen Shot 2021-03-30 at 1 11 51 PM" src="https://user-images.githubusercontent.com/21203253/113028713-9867fa00-9159-11eb-8498-30ecbd0fdb6c.png">

Focused Link:
<img width="1679" alt="Screen Shot 2021-03-30 at 1 11 44 PM" src="https://user-images.githubusercontent.com/21203253/113028741-a289f880-9159-11eb-9913-179e1cf9f7fa.png">

Test with ChromeVox (audio) showing that selecting the Skip to Content skips the Nav and goes directly to focus on the "Welcome to Jam3."


https://user-images.githubusercontent.com/21203253/113030134-43c57e80-915b-11eb-8d6e-1af96990251a.mp4


<!--- Describe your changes in detail -->

## Side Effects, Risks, Impact

Let me know if I should add the advisor warning to `adviserrc.json`.

**Additional comments:**
