### PR TITLE
feature: add eslint next package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["react-app", "react-jam3"],
+  "extends": ["react-app", "react-jam3", "plugin:@next/next/recommended"],
   "plugins": ["jam3"],
   "settings": {
     "react": {
@@ -59,7 +59,8 @@
           ]
         }
       }
-    ]
+    ],
+    "@next/next/no-img-element": "off"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "cross-env": "7.0.3",
     "dotenv": "8.6.0",
     "eslint": "7.27.0",
+    "eslint-config-next": "^11.0.1",
     "eslint-config-postcss": "4.0.0",
     "eslint-config-prettier": "7.2.0",
     "eslint-config-react-app": "6.0.0",


### PR DESCRIPTION
Next 11 released an eslint package with next specific warnings

Reference: https://nextjs.org/docs/basic-features/eslint

Some warnings like images are not useful to us because we don't use Vercel but still should be nice to have
