### PR TITLE
fix: remove custom scss module webpack config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -50,15 +50,6 @@ const nextJSConfig = {
     includePaths: [path.join(__dirname, 'src/styles')]
   },
   webpack: function (config, options) {
-    const moduleSassRule = config.module.rules[2].oneOf.find(
-      (rule) => rule.test.toString() === /\.module\.(scss|sass)$/.toString()
-    );
-
-    if (moduleSassRule) {
-      const cssLoader = moduleSassRule.use.find(({ loader }) => loader.includes('css-loader'));
-      if (cssLoader) cssLoader.options.modules.mode = 'local';
-    }
-
     if (options.dev) {
       config.module.rules.push({
         test: /.\/src\/.*\/.*.js$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2611,18 +2611,17 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "optional": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "globby": {
@@ -3658,9 +3657,9 @@
           "optional": true
         },
         "acorn-walk": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
-          "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
+          "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
           "dev": true,
           "optional": true
         }
@@ -3828,17 +3827,16 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "file-type": {
@@ -5917,9 +5915,9 @@
       }
     },
     "@storybook/builder-webpack5": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-6.3.0.tgz",
-      "integrity": "sha512-cEP/8UaGnE1tzobk3oZGaF1HySlmLq3zZgVRVwTYO8IMCM/OT/XHbWkeDnPCisj50KN0XL0a00ZRTSl2J4gszg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-6.3.1.tgz",
+      "integrity": "sha512-fMExOyYQUo68G0L8zaVq7w+XsPUYpwXYBoPzw6dLKxvTI4hY3jk7bcvdXOH3/m/5jkadeFFh4/wYNAfvF0JgYg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.10",
@@ -5942,19 +5940,19 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
-        "@storybook/addons": "6.3.0",
-        "@storybook/api": "6.3.0",
-        "@storybook/channel-postmessage": "6.3.0",
-        "@storybook/channels": "6.3.0",
-        "@storybook/client-api": "6.3.0",
-        "@storybook/client-logger": "6.3.0",
-        "@storybook/components": "6.3.0",
-        "@storybook/core-common": "6.3.0",
-        "@storybook/core-events": "6.3.0",
-        "@storybook/node-logger": "6.3.0",
-        "@storybook/router": "6.3.0",
+        "@storybook/addons": "6.3.1",
+        "@storybook/api": "6.3.1",
+        "@storybook/channel-postmessage": "6.3.1",
+        "@storybook/channels": "6.3.1",
+        "@storybook/client-api": "6.3.1",
+        "@storybook/client-logger": "6.3.1",
+        "@storybook/components": "6.3.1",
+        "@storybook/core-common": "6.3.1",
+        "@storybook/core-events": "6.3.1",
+        "@storybook/node-logger": "6.3.1",
+        "@storybook/router": "6.3.1",
         "@storybook/semver": "^7.3.2",
-        "@storybook/theming": "6.3.0",
+        "@storybook/theming": "6.3.1",
         "@types/node": "^14.0.10",
         "babel-loader": "^8.2.2",
         "babel-plugin-macros": "^3.0.1",
@@ -5962,7 +5960,7 @@
         "case-sensitive-paths-webpack-plugin": "^2.3.0",
         "core-js": "^3.8.2",
         "css-loader": "^5.0.1",
-        "dotenv-webpack": "^6.0.0",
+        "dotenv-webpack": "^7.0.0",
         "fork-ts-checker-webpack-plugin": "^6.0.4",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
@@ -5981,36 +5979,36 @@
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.0.tgz",
-          "integrity": "sha512-/dcq20HtdSw5+cG8znR59Y/uv2zCR2VjRK3N52IkGWk162b/UbSjjL0PhNnnQFGpH9Fruft6mqvjTAKT41kmJw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.1.tgz",
+          "integrity": "sha512-wDDqhd/jOXo752LQmNFdWlQOdzk/ZcsnOELXUpGY8QWzS9uasR1rZzCR78sFzsUTRyyMDAeiVHmKUlD2n4EL0g==",
           "dev": true,
           "requires": {
-            "@storybook/api": "6.3.0",
-            "@storybook/channels": "6.3.0",
-            "@storybook/client-logger": "6.3.0",
-            "@storybook/core-events": "6.3.0",
-            "@storybook/router": "6.3.0",
-            "@storybook/theming": "6.3.0",
+            "@storybook/api": "6.3.1",
+            "@storybook/channels": "6.3.1",
+            "@storybook/client-logger": "6.3.1",
+            "@storybook/core-events": "6.3.1",
+            "@storybook/router": "6.3.1",
+            "@storybook/theming": "6.3.1",
             "core-js": "^3.8.2",
             "global": "^4.4.0",
             "regenerator-runtime": "^0.13.7"
           }
         },
         "@storybook/api": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.0.tgz",
-          "integrity": "sha512-swPMcQadLDRTnMjL9dwY6K1zXHn3KcAa3euvSHd1R4OKXTSBBj1zHvIaOrq6yHz7RIYOACmZlEV3CUru9FlvEA==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.3.1.tgz",
+          "integrity": "sha512-70T9xaKWMP9xE4zOLLQiqmmWbsYk3nAFfwSnCu8oGb2Iq5bwfGDnm///n1/84OkObYv4OzVoRbIyLD+Xsx1Fnw==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.3.4",
-            "@storybook/channels": "6.3.0",
-            "@storybook/client-logger": "6.3.0",
-            "@storybook/core-events": "6.3.0",
+            "@storybook/channels": "6.3.1",
+            "@storybook/client-logger": "6.3.1",
+            "@storybook/core-events": "6.3.1",
             "@storybook/csf": "0.0.1",
-            "@storybook/router": "6.3.0",
+            "@storybook/router": "6.3.1",
             "@storybook/semver": "^7.3.2",
-            "@storybook/theming": "6.3.0",
+            "@storybook/theming": "6.3.1",
             "@types/reach__router": "^1.3.7",
             "core-js": "^3.8.2",
             "fast-deep-equal": "^3.1.3",
@@ -6026,14 +6024,14 @@
           }
         },
         "@storybook/channel-postmessage": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.0.tgz",
-          "integrity": "sha512-q7FeNWIIrvZxycIMBscqahFLygxAa2L4eJ9oxZFF9zJpSV80bxDalMou3Uo7RvDJFrAeHCanF1Y7bnEDMus4yg==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.1.tgz",
+          "integrity": "sha512-6+luEe2H/84ZYCfcNgH5WCYtUbSIJiMjKFsV17iRVLECRxX8PtxxH5zB3kzhpAngp9WwKDEAS0T1+lEZoHh2Yw==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "6.3.0",
-            "@storybook/client-logger": "6.3.0",
-            "@storybook/core-events": "6.3.0",
+            "@storybook/channels": "6.3.1",
+            "@storybook/client-logger": "6.3.1",
+            "@storybook/core-events": "6.3.1",
             "core-js": "^3.8.2",
             "global": "^4.4.0",
             "qs": "^6.10.0",
@@ -6041,9 +6039,9 @@
           }
         },
         "@storybook/channels": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.0.tgz",
-          "integrity": "sha512-E+SCQLSIlCaOGKEkZ8rFKNyH24/N4IA6h+EDF+9mhw3yT4iv7NCoswCgqX7JhyhSjWkM01onhuMVUVKVvi7CSw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.1.tgz",
+          "integrity": "sha512-mMOQmXylE9yTHNp2uOdEg70Wb5KsPxV5mEHcYzYE54UM8HsYzeFu5UwG/CSA7FAkCHgCZfNiCW0LhikRN4bNbQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.8.2",
@@ -6052,16 +6050,16 @@
           }
         },
         "@storybook/client-api": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.0.tgz",
-          "integrity": "sha512-5HLtYPBOHif9AdzwLCrVbMQdOJ2dne9zv7oTo6Yl0wvLhbr6V/VypoXE0CgFF3hAI2iUquG5z00KlrE8UErC5Q==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.1.tgz",
+          "integrity": "sha512-LZrJ5zUT88n2VIf4c+3IkWXWmBzpz5DMc9ly2KOPywzgAPkTOwRzaNY6lg2ozMhN262N5meRAST86kYRYG3DKw==",
           "dev": true,
           "requires": {
-            "@storybook/addons": "6.3.0",
-            "@storybook/channel-postmessage": "6.3.0",
-            "@storybook/channels": "6.3.0",
-            "@storybook/client-logger": "6.3.0",
-            "@storybook/core-events": "6.3.0",
+            "@storybook/addons": "6.3.1",
+            "@storybook/channel-postmessage": "6.3.1",
+            "@storybook/channels": "6.3.1",
+            "@storybook/client-logger": "6.3.1",
+            "@storybook/core-events": "6.3.1",
             "@storybook/csf": "0.0.1",
             "@types/qs": "^6.9.5",
             "@types/webpack-env": "^1.16.0",
@@ -6078,9 +6076,9 @@
           }
         },
         "@storybook/client-logger": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.0.tgz",
-          "integrity": "sha512-x/y820f/2Jm6RW5TxRv7IlbF6zWpTkHoajfwYuTpK/OXvK5gx6dwXGdgjNoaAGofGRz5SVjDjTDPOcd5X5AUPw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.3.1.tgz",
+          "integrity": "sha512-S43DOYVHyb7KXx+UZh/3Rl5NroG+sTkE+JAu7/DWUQ3B1H1rPacOcZUiclfxrh7uaCtJXmYVsa1ud3UEEnzxtA==",
           "dev": true,
           "requires": {
             "core-js": "^3.8.2",
@@ -6088,15 +6086,15 @@
           }
         },
         "@storybook/components": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.0.tgz",
-          "integrity": "sha512-TDcazQAtNgE1E33jKKABx51XpvWyXMcJZFWA0d5wu8XrElrL1PuZqz7dPePoWKGMfTaPYWP6rRyDg4Svv36j+A==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.3.1.tgz",
+          "integrity": "sha512-sCNalGXSMzVCoElRUYKS+EuIJQr5zNbPepFVzZWXGj2cKd7z6LtHNyEN/3eTnR7Ivdpaf43IZc9pIBmBvSmIFQ==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.6.0",
-            "@storybook/client-logger": "6.3.0",
+            "@storybook/client-logger": "6.3.1",
             "@storybook/csf": "0.0.1",
-            "@storybook/theming": "6.3.0",
+            "@storybook/theming": "6.3.1",
             "@types/color-convert": "^2.0.0",
             "@types/overlayscrollbars": "^1.12.0",
             "@types/react-syntax-highlighter": "11.0.5",
@@ -6120,22 +6118,22 @@
           }
         },
         "@storybook/core-events": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
-          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.1.tgz",
+          "integrity": "sha512-W+0eRG955kd0HlD+8gGNeXogEnxEugfjDr9g316vawYlz9qnPoBxad8LoLPys5RawboK+1erOEfI2owGqDiKHw==",
           "dev": true,
           "requires": {
             "core-js": "^3.8.2"
           }
         },
         "@storybook/router": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.0.tgz",
-          "integrity": "sha512-RJcRVI6IqffLOU6k9GrlB3cXLLK5TRmFSIjwW3lEHVhj313e56uLRYTylT11aBf8bPEQ+MeQVe2sqQUBG3Ugng==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.3.1.tgz",
+          "integrity": "sha512-7YZlXdkWTttvK5OvqCjP8V8KdYx3FfTG0aKIo0koTsq1O09pPvM8aoNUZ0bNeEq9yE+1CLPiickaBtA9A29q2Q==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.3.4",
-            "@storybook/client-logger": "6.3.0",
+            "@storybook/client-logger": "6.3.1",
             "@types/reach__router": "^1.3.7",
             "core-js": "^3.8.2",
             "fast-deep-equal": "^3.1.3",
@@ -6157,15 +6155,15 @@
           }
         },
         "@storybook/theming": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.0.tgz",
-          "integrity": "sha512-Mtnq8qFv/TTtnl1sB6DGBCg/kJq7sR2e2uh/Uy2sHyksnhVITVJxEIFHSBo2L+IE6y0S2Oh6F9WdddWAO4Ao2g==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.3.1.tgz",
+          "integrity": "sha512-YDXv7QFMqfl/S2TVlvvUzO0CtNPbA/Pf1uHb9aUxcmUPvh/uZsuTXvahWqaRDF4hv+NjxEPPXK6ofd0fBTKEjQ==",
           "dev": true,
           "requires": {
             "@emotion/core": "^10.1.1",
             "@emotion/is-prop-valid": "^0.8.6",
             "@emotion/styled": "^10.0.27",
-            "@storybook/client-logger": "6.3.0",
+            "@storybook/client-logger": "6.3.1",
             "core-js": "^3.8.2",
             "deep-object-diff": "^1.1.0",
             "emotion-theming": "^10.0.27",
@@ -6631,9 +6629,9 @@
       }
     },
     "@storybook/core-common": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.3.0.tgz",
-      "integrity": "sha512-AYoN1g8g4FI2K2UcGfLAm7EUPgesiClLT/zqy2q6dWQrIUayWzJqI+gqDyYukv5s+KHRanGBZNCTBww/VhcPlg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-6.3.1.tgz",
+      "integrity": "sha512-c0ZvZo52SwzL3xI+C7ux+wCpq0uDIXiau4S9LoeKHjRUc1vFyrQKgkQ0UeKXk43DhhlpVYdxw88ZyFHkeNCaEg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.10",
@@ -6657,7 +6655,7 @@
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
         "@babel/register": "^7.12.1",
-        "@storybook/node-logger": "6.3.0",
+        "@storybook/node-logger": "6.3.1",
         "@storybook/semver": "^7.3.2",
         "@types/glob-base": "^0.3.0",
         "@types/micromatch": "^4.0.1",
@@ -8179,9 +8177,9 @@
       }
     },
     "@storybook/node-logger": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.0.tgz",
-      "integrity": "sha512-gxvYOwDzHSYDTvnrwsyonCk88lRQ9gHrEvu3J8sM/0G/0br8g7G8+jSakKR8miE7urcwxd0uoYK+Y4KwJHkJpg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.1.tgz",
+      "integrity": "sha512-1nyevS5a/B5zoYfMYFh98ll7mWTjHOLy8YZIfF6TEg3F4IIZDu3R0NoRMuXW3qCPmhVrHA1Rts0G5jzi157IUw==",
       "dev": true,
       "requires": {
         "@types/npmlog": "^4.1.2",
@@ -9076,9 +9074,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
+      "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==",
       "dev": true
     },
     "@types/estree-jsx": {
@@ -9213,9 +9211,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "@types/node-fetch": {
       "version": "2.5.10",
@@ -9446,14 +9444,14 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.0.tgz",
-      "integrity": "sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
+      "integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "debug": "^4.3.1"
       },
       "dependencies": {
@@ -9475,29 +9473,29 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
-      "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+      "integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0"
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
-      "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
-      "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -9536,17 +9534,16 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "globby": {
@@ -9624,12 +9621,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
-      "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
         "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
@@ -11226,35 +11223,16 @@
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
-        "css-select": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-          "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
-          "dev": true,
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^4.0.0",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.4.3",
-            "nth-check": "^2.0.0"
-          }
-        },
-        "css-what": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-          "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
-          "dev": true
-        },
         "svgo": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.0.tgz",
-          "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
+          "integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
           "dev": true,
           "requires": {
             "@trysound/sax": "0.1.1",
             "chalk": "^4.1.0",
             "commander": "^7.1.0",
-            "css-select": "^3.1.2",
+            "css-select": "^4.1.3",
             "css-tree": "^1.1.2",
             "csso": "^4.2.0",
             "stable": "^0.1.8"
@@ -12812,15 +12790,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001239.tgz",
-      "integrity": "sha512-J79zAGPxlnkCPrDWaEpAUNMsU7Z1vwWRm8TVEZAI98Z4FN1UgFZuP8P4YZvFrNfI7HGDwRM55Fll3lOG0CM9Kw==",
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001241.tgz",
+      "integrity": "sha512-Fa2E9oRfosfhtlR+zbfgdxHgJeMYqlnLBIcMO/tRb5ftTFJ31PG1JSgfyYzfoQw+n+xfk0sH7J2cgB7Rm17+dg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ=="
     },
     "canonicalize": {
       "version": "1.0.5",
@@ -14129,15 +14107,15 @@
       }
     },
     "core-js": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz",
-      "integrity": "sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.1.tgz",
-      "integrity": "sha512-xGhzYMX6y7oEGQGAJmP2TmtBLvR4nZmRGEcFa3ubHOq5YEp51gGN9AovVa0AoujGZIq+Wm6dISiYyGNfdflYww==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
+      "integrity": "sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -14153,9 +14131,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz",
-      "integrity": "sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
+      "integrity": "sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==",
       "dev": true
     },
     "core-util-is": {
@@ -15286,9 +15264,9 @@
           "optional": true
         },
         "whatwg-url": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-          "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -15341,9 +15319,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.0.tgz",
-      "integrity": "sha512-MrQRs2gyD//7NeHi9TtsfClkf+cFAewDz+PZHR8ILKglLmBMyVX3ymQ+oeznE3tjrS7beTN+6JXb2C3JDHm7ug==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true,
       "optional": true
     },
@@ -16244,12 +16222,12 @@
       "dev": true
     },
     "dotenv-webpack": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-6.0.4.tgz",
-      "integrity": "sha512-WiTPNLanDNJ1O8AvgkBpsbarw78a4PMYG2EfJcQoxTHFWy+ji213HR+3f4PhWB1RBumiD9cbiuC3SNxJXbBp9g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz",
+      "integrity": "sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==",
       "dev": true,
       "requires": {
-        "dotenv-defaults": "^2.0.1"
+        "dotenv-defaults": "^2.0.2"
       }
     },
     "double-ended-queue": {
@@ -16380,9 +16358,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.757",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.757.tgz",
-      "integrity": "sha512-kP0ooyrvavDC+Y9UG6G/pUVxfRNM2VTJwtLQLvgsJeyf1V+7shMCb68Wj0/TETmfx8dWv9pToGkVT39udE87wQ=="
+      "version": "1.3.761",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.761.tgz",
+      "integrity": "sha512-7a/wV/plM/b95XjTdA2Q4zAxxExTDKkNQpTiaU/nVT8tGCQVtX9NsnTjhALBFICpOB58hU6xg5fFC3CT2Bybpg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -20155,17 +20133,16 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "get-stream": {
@@ -22660,9 +22637,9 @@
           "optional": true
         },
         "whatwg-url": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-          "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -22672,9 +22649,9 @@
           }
         },
         "ws": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-          "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+          "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
           "dev": true,
           "optional": true
         }
@@ -31745,13 +31722,10 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+      "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -32092,9 +32066,9 @@
       }
     },
     "puppeteer-core": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.0.0.tgz",
-      "integrity": "sha512-kaNsKhNYcayHnlwpkBf1w/lhyi1zUSHGLgh5z6DwhTbTrVN0pQHjWj7/TNBooop5Ehv0H7KFuH5QTbxrRFeDdA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.1.0.tgz",
+      "integrity": "sha512-x2yDSJI/PRiWhDqAt1jd4rhTotxwjwKzHLIIqD2MlJ+TmzGJfBY9snAGIVXJwkWfKJg+Ef5xupdK0EbHDqBpFw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -32485,16 +32459,15 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "find-up": {
@@ -33111,6 +33084,17 @@
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
         "prismjs": "~1.23.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+          "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        }
       }
     },
     "regenerate": {
@@ -35953,17 +35937,16 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "find-up": {
@@ -37525,15 +37508,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz",
-      "integrity": "sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+      "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
       "dev": true,
       "requires": {
         "jest-worker": "^27.0.2",
         "p-limit": "^3.1.0",
         "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1",
+        "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
         "terser": "^5.7.0"
       },
@@ -37545,9 +37528,9 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "27.0.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-          "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+          "version": "27.0.6",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+          "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -37567,9 +37550,9 @@
           }
         },
         "serialize-javascript": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-          "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
           "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
@@ -37591,9 +37574,9 @@
           }
         },
         "terser": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-          "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+          "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -38031,9 +38014,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "dev": true,
       "optional": true
     },
@@ -38997,16 +38980,15 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+          "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "file-type": {
@@ -39088,13 +39070,13 @@
       }
     },
     "webpack": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.40.0.tgz",
-      "integrity": "sha512-c7f5e/WWrxXWUzQqTBg54vBs5RgcAgpvKE4F4VegVgfo4x660ZxYUF2/hpMkZUnLjgytVTitjeXaN4IPlXCGIw==",
+      "version": "5.41.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.41.1.tgz",
+      "integrity": "sha512-AJZIIsqJ/MVTmegEq9Tlw5mk5EHdGiJbDdz9qP15vmUH+oxI1FdWcL0E9EO8K/zKaRPWqEs7G/OPxq1P61u5Ug==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.47",
+        "@types/estree": "^0.0.48",
         "@webassemblyjs/ast": "1.11.0",
         "@webassemblyjs/wasm-edit": "1.11.0",
         "@webassemblyjs/wasm-parser": "1.11.0",


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [x] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
NextJS 10+ now support CSS/SCSS as well as CSS and SCSS `modules` by default.
https://nextjs.org/docs/basic-features/built-in-css-support#sass-support

## Solution Description
removing the custom webpack config.

## Side Effects, Risks, Impact

No side effects at all. The app will run as before.

**Aditional comments:**
