### PR TITLE
Add Jira support in every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
 -->
 
+<!--- JIRA Ticket Link -->
+Jira Ticket ID: <JIRA Ticket ID> <!--- Example: JRA-34 -->
+
 <!--- Provide a general summary of your changes in the PR Title -->
 
 **What kind of change does this PR introduce?** (check at least one)


### PR DESCRIPTION
## Problem
Github PRs are not integrated with Jira

## Change
1. Add the Jira ticket id in the Pull Request Template

## Description
If Jira is integrated with Github, adding the Jira Ticket ID it's going to link a specific ticket with the commits.

## Other
To learn more check: https://support.atlassian.com/jira-software-cloud/docs/process-issues-with-smart-commits/