### PR TITLE
chore: rename Landing to Home

### DIFF
--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -4,12 +4,12 @@ export type Route = {
 };
 
 export interface Routes {
-  readonly Landing: Route;
+  readonly Home: Route;
   readonly About: Route;
 }
 
 const routes: Routes = {
-  Landing: {
+  Home: {
     path: '/',
     title: 'Home'
   },

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -1,6 +1,6 @@
 @import 'shared';
 
-.Landing {
+.Home {
   > .hero {
     width: 100%;
     color: #333;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,11 +9,11 @@ type Props = {
   className: string;
 };
 
-function Landing({ className }: Props) {
+function Home({ className }: Props) {
   const containerRef = useRef<HTMLElement>(null);
 
   return (
-    <main className={classnames(styles.Landing, className)} ref={containerRef}>
+    <main className={classnames(styles.Home, className)} ref={containerRef}>
       <Head />
       <section className={styles.hero}>
         <h1 className={styles.title}>Welcome to Jam3!</h1>
@@ -44,4 +44,4 @@ function Landing({ className }: Props) {
   );
 }
 
-export default memo(Landing);
+export default memo(Home);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,6 @@ export type ExampleRoute = {
 };
 
 export interface ExampleRoutes {
-  readonly Landing: ExampleRoute;
+  readonly Home: ExampleRoute;
   readonly About: ExampleRoute;
 }


### PR DESCRIPTION
I have been wanting to do this for a while 😂 

the main reason being: "Landing" should be the page users land on, although sometimes it's likely to be the root page; on the other hand, "Home" normally means the root page, which I think is more concise...

let me know what you think 😂 



also, on an unrelated note, I think "JAMstack" is now called "Jamstack" (different casing), maybe we want to change it in the repo description on the right