### PR TITLE
Optional static HTML flash removal UP FOR DISCUSSION

### DIFF
--- a/src/data/settings.ts
+++ b/src/data/settings.ts
@@ -1,5 +1,6 @@
 // Global
 export const resizeDebounceTime = 10; // in ms
+export const hideStaticHtml = false; // sets page to be invisible until FE app kicks in (removes static content flash)
 
 // Head
 export const siteName = 'Jam3 Generator';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,14 @@
 import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 
+import sanitizer from '@/utils/sanitizer';
+
+import { hideStaticHtml } from '@/data/settings';
+
+// if JS is available we hide the page immediately to prevent static content flash.
+const hideStaticHtmlScript = `
+  if (typeof window !== 'undefined') document.documentElement.classList.add('hide-static-html');
+`;
+
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -10,7 +19,9 @@ class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head />
-
+        {hideStaticHtml && (
+          <script data-cfasync="false" dangerouslySetInnerHTML={{ __html: sanitizer(hideStaticHtmlScript) }} />
+        )}
         <body>
           <Main />
           <NextScript />

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -14,6 +14,11 @@ html {
   text-size-adjust: none;
   font-size: 10px;
   text-align: center;
+
+  &.hide-static-html {
+    visibility: hidden;
+    opacity: 0;
+  }
 }
 
 body {

--- a/src/utils/set-body-classes.ts
+++ b/src/utils/set-body-classes.ts
@@ -1,5 +1,7 @@
 import { browser, device, os } from '@jam3/detect';
 
+import { hideStaticHtml } from '@/data/settings';
+
 function setBodyClasses() {
   const classes = [
     device.mobile ? 'mobile-device' : '',
@@ -9,6 +11,11 @@ function setBodyClasses() {
     os.name
   ].filter(Boolean);
   classes.forEach((c) => document.body.classList.add(c.toLowerCase().split(' ').join('-')));
+
+  // un-hide page once application kicked in
+  if (hideStaticHtml) {
+    document.documentElement.classList.remove('hide-static-html');
+  }
 }
 
 export default setBodyClasses;


### PR DESCRIPTION
Optional fix for static content flash -  FE won't show pre-rendered HTML until the app kicks in.
This is sort of decreases performance (1st meaningful pain) but makes sure motion works seamlessly on site load.

We can also set default to `false` if we like

This won't impact statically pre-rendered HTML and will display content with disabled JS as expected.