### PR TITLE
feature: update Docker's node build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:14
+FROM node:14-bullseye
 LABEL maintainer_devops="michael.silva@jam3.com"
 LABEL maintainer_architect="iran.reyes@jam3.com"
 
-# Upgrade npm 
+# Upgrade npm
 RUN npm install -g npm@7
 
 # Set working directory


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**
We used this fix in a couple of projects to fix Codeship build breaking

## Problem Description
`node:14` docker image as its build environment which has node version 14.17.6.
That image is built on an OS (debian stretch) that comes with `zlib1g 1.2.8`, which does not satisfy building the `mozjpeg` dependency based on required `zlib1g 1.2.9+`. See https://packages.debian.org/bullseye/zlib1g
Build a result build breaks:
![image](https://user-images.githubusercontent.com/4369064/149577759-d3fa81d2-ea85-46d9-96f1-c6473c64040d.png)


## Solution Description
Use another node image - `node:14-bullseye` that comes with comes with `zlib 1.2.11`
