### PR TITLE
feature: gsap init + improvements [proposal]

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,9 @@ import { RouterContext } from 'next/dist/shared/lib/router-context'; // next 11.
 import '../src/styles/global.scss';
 
 import { store } from '../src/redux';
+import gsapInit from '../src/utils/gsap-init';
+
+gsapInit();
 
 export const decorators = [
   (Story) => (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import classnames from 'classnames';
 import Link from 'next/link';
 
@@ -17,8 +18,10 @@ const LINKS = [
 }));
 
 function Nav() {
+  const containerRef = useRef<HTMLElement>(null);
+
   return (
-    <nav className={classnames(styles.Nav)}>
+    <nav className={classnames(styles.Nav)} ref={containerRef}>
       <div className={styles.wrapper}>
         <ul className={styles.routes}>
           <a tabIndex={0} aria-label="Skip to content" className={styles.skipToContent} href="#start-of-content">

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,12 +11,14 @@ import Layout from '@/components/Layout/Layout';
 
 import { store } from '@/redux';
 import '@/utils/why-did-you-render';
+import gsapInit from '@/utils/gsap-init';
 
 const isBrowser = typeof window !== 'undefined';
 
 if (isBrowser) {
   require('default-passive-events');
   require('focus-visible');
+  gsapInit();
 }
 
 // This default export is required in a new `pages/_app.js` file.

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,5 +1,6 @@
-import { memo, useRef } from 'react';
+import { memo, useRef, useEffect } from 'react';
 import classnames from 'classnames';
+import gsap from 'gsap';
 
 import styles from './index.module.scss';
 
@@ -11,11 +12,23 @@ type Props = {
 
 function About({ className }: Props) {
   const containerRef = useRef<HTMLElement>(null);
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    const headerElRef = headerRef.current;
+    gsap.effects.fadeIn(headerElRef, { delay: 0.1 });
+
+    return () => {
+      gsap.killTweensOf(headerElRef);
+    };
+  }, []);
 
   return (
     <main className={classnames(styles.About, className)} ref={containerRef}>
       <Head title="About" />
-      <h1 className={styles.title}>About Page</h1>
+      <h1 className={styles.title} ref={headerRef}>
+        About Page
+      </h1>
     </main>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
-import { useRef, memo } from 'react';
+import { useRef, memo, useEffect } from 'react';
 import classnames from 'classnames';
+import gsap from 'gsap';
 
 import styles from './index.module.scss';
 
@@ -10,17 +11,34 @@ type Props = {
 };
 
 function Home({ className }: Props) {
-  const containerRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const descriptionRef = useRef<HTMLHeadingElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    const timeline = gsap
+      .timeline({ delay: 0.1 })
+      .fadeIn(titleRef.current, 0.2)
+      .fadeIn(descriptionRef.current, 0.4)
+      .fadeIn(listRef.current?.childNodes, { stagger: 0.1 }, 0.6);
+
+    return () => {
+      timeline.kill();
+    };
+  }, []);
 
   return (
     <main className={classnames(styles.Home, className)} ref={containerRef}>
       <Head />
       <section className={styles.hero}>
-        <h1 className={styles.title}>Welcome to Jam3!</h1>
-        <h2 className={styles.description}>
+        <h1 className={styles.title} ref={titleRef}>
+          Welcome to Jam3!
+        </h1>
+        <h2 className={styles.description} ref={descriptionRef}>
           To get started, edit <code>pages/index.js</code> and save to reload.
         </h2>
-        <ul className={styles.row}>
+        <ul className={styles.row} ref={listRef}>
           <li>
             <a
               href="https://github.com/Jam3?q=&type=source"

--- a/src/utils/gsap-init.ts
+++ b/src/utils/gsap-init.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import gsap from 'gsap';
+import ScrollToPlugin from 'gsap/dist/ScrollToPlugin';
+import ScrollTrigger from 'gsap/dist/ScrollTrigger';
+
+function gsapInit() {
+  gsap.registerPlugin(ScrollToPlugin, ScrollTrigger);
+  gsap.defaults({ ease: 'power2.out', duration: 0.333 });
+  gsap.config({ nullTargetWarn: false });
+
+  gsap.registerEffect({
+    name: 'fadeIn',
+    extendTimeline: true,
+    effect: (targets: any, config: any) => {
+      return gsap.from(targets, {
+        duration: config.duration,
+        autoAlpha: 0,
+        y: config.y,
+        delay: config.delay,
+        stagger: config.stagger
+      });
+    },
+    defaults: { duration: 0.667, y: 20, delay: 0, stagger: 0 }
+  });
+}
+
+export default gsapInit;


### PR DESCRIPTION
This PR main goal is too add `gsap-init` which will fix a couple important things:
- storybook where animations won't work even if we import gsap in our components
- `scroll-page` util; because this util which is used by the lock service is using `ScrollToPlugin` from gsap right now by default doesn't work since we're not importing this anywhere, therefore vertical positioning is not getting restored.

Then some more proposals:
- Add a bit of motion as default on our pages, so for example coops have an idea of how we do motion from the beginning (but I could see how this might be too much and is better to keep the generator clean)
- Then probably the most spicy `registerEffect` I think we as a company we should start to use this https://greensock.com/docs/v3/GSAP/gsap.registerEffect() since we repeat ourselves sometimes a lot in projects when it comes to animation, things like fade from the bottom animations usually in motion bibles are all the same, and registerEffect allows for variations anyways

Personally I have only used registerEffect in personal projects and coops projects so I don't have a production example that it works perfect but it should and also the greensock overlords talked about this in the presentation that they did here.
