### PR TITLE
feature: automatic eslint import sort

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "plugin:import/typescript",
     "prettier"
   ],
-  "plugins": ["jam3"],
+  "plugins": ["jam3", "simple-import-sort"],
   "parser": "@typescript-eslint/parser",
   "settings": {
     "react": {
@@ -20,6 +20,23 @@
     }
   },
   "rules": {
+    "import/order": "off",
+    "simple-import-sort/exports": "warn",
+    "simple-import-sort/imports": [
+      "warn",
+      {
+        "groups": [
+          ["^react", "^next", "^@jam3", "^@?\\w", "^\\u0000"], // our stack & ext library & side effect
+          ["^.+\\.scss$", "^@/styles/.+\\.scss$"], // css & scss
+          ["^@/pages", "^@/components"], // components
+          ["^@/services", "^@/utils", "^@/hooks", "^@/types"], // utils
+          ["^@/redux"], // redux
+          ["^@/components/svgs", "^@/data", "^@/assets"], // data
+          ["^@/"], // other basePaths
+          ["^"] // rest
+        ]
+      }
+    ],
     "prettier/prettier": "warn",
     "import/no-anonymous-default-export": "off",
     "jam3/no-sanitizer-with-danger": [

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-promise": "5.1.0",
     "eslint-plugin-react": "7.25.1",
     "eslint-plugin-react-hooks": "4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "husky": "7.0.4",
     "imagemin-gifsicle": "6.0.1",
     "imagemin-mozjpeg": "9.0.0",

--- a/src/components/AppAdmin/AppAdmin.tsx
+++ b/src/components/AppAdmin/AppAdmin.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from 'react';
-import { os, browser, device } from '@jam3/detect';
 import { useWindowSize } from 'react-use';
+import { browser, device, os } from '@jam3/detect';
 import classnames from 'classnames';
 
 import styles from './AppAdmin.module.scss';

--- a/src/components/CookieBanner/CookieBanner.tsx
+++ b/src/components/CookieBanner/CookieBanner.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState, PropsWithChildren } from 'react';
+import { memo, PropsWithChildren, useCallback, useState } from 'react';
 import classnames from 'classnames';
 import noop from 'no-op';
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import classnames from 'classnames';
 import Link from 'next/link';
+import classnames from 'classnames';
 
 import styles from './Footer.module.scss';
 

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import NextHead from 'next/head';
 import dynamic from 'next/dynamic';
+import NextHead from 'next/head';
 import { useRouter } from 'next/router';
 
 import { siteName, siteSlogan } from '@/data/settings';

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,10 +1,11 @@
-import { memo, forwardRef, useMemo, ForwardedRef } from 'react';
+import { ForwardedRef, forwardRef, memo, useMemo } from 'react';
 import classnames from 'classnames';
 
 import styles from './Image.module.scss';
 import sassVars from '@/styles/export-vars.module.scss';
 
 import { Breakpoints } from '@/utils/layout';
+
 import { useAppSelector } from '@/redux';
 
 type SrcSetSizes = {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,16 +1,17 @@
-import { memo, useEffect, useCallback, PropsWithChildren } from 'react';
+import { memo, PropsWithChildren, useCallback, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { device } from '@jam3/detect';
 
-import Nav from '@/components/Nav/Nav';
-import Footer from '@/components/Footer/Footer';
 import CookieBanner from '@/components/CookieBanner/CookieBanner';
-import { GtmScript } from '@/utils/analytics';
+import Footer from '@/components/Footer/Footer';
+import Nav from '@/components/Nav/Nav';
 
-import { setPrevRoute, setIsWebpSupported, useAppDispatch } from '@/redux';
+import { GtmScript } from '@/utils/analytics';
 import { checkWebpSupport } from '@/utils/basic-functions';
 import useCookieBanner from '@/hooks/use-cookie-banner';
+
+import { setIsWebpSupported, setPrevRoute, useAppDispatch } from '@/redux';
 
 const AppAdmin = dynamic(() => import('@/components/AppAdmin/AppAdmin'), { ssr: false });
 const RotateScreen = dynamic(() => import('@/components/RotateScreen/RotateScreen'), { ssr: false });

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,11 +1,11 @@
-import classnames from 'classnames';
 import Link from 'next/link';
+import classnames from 'classnames';
 
 import styles from './Nav.module.scss';
 
 import Image from '@/components/Image/Image';
-import SvgThreeLogo from '@/components/svgs/three-logo.svg';
 
+import SvgThreeLogo from '@/components/svgs/three-logo.svg';
 import routes from '@/data/routes';
 
 const LINKS = [

--- a/src/components/RotateScreen/RotateScreen.stories.tsx
+++ b/src/components/RotateScreen/RotateScreen.stories.tsx
@@ -1,4 +1,5 @@
 import { device } from '@jam3/detect';
+
 import Component, { Props } from './RotateScreen';
 
 export default { title: 'components/RotateScreen' };

--- a/src/components/RotateScreen/RotateScreen.tsx
+++ b/src/components/RotateScreen/RotateScreen.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useState } from 'react';
-import classnames from 'classnames';
 import { device } from '@jam3/detect';
+import classnames from 'classnames';
 
 import styles from './RotateScreen.module.scss';
 

--- a/src/hooks/use-layout.ts
+++ b/src/hooks/use-layout.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useWindowSize } from '@jam3/react-hooks';
 
-import { resizeDebounceTime } from '@/data/settings';
 import layout, { Breakpoints } from '@/utils/layout';
+
+import { resizeDebounceTime } from '@/data/settings';
 
 /**
  * Layout hook

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { AppProps } from 'next/app';
-import { device, browser } from '@jam3/detect';
+import { browser, device } from '@jam3/detect';
 import classnames from 'classnames';
-
 import 'normalize.css';
+import '@/utils/why-did-you-render';
+
 import '@/styles/global.scss';
 
 import Layout from '@/components/Layout/Layout';
 
 import { store } from '@/redux';
-import '@/utils/why-did-you-render';
 
 const isBrowser = typeof window !== 'undefined';
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,4 @@
-import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, memo } from 'react';
+import { memo, useRef } from 'react';
 import classnames from 'classnames';
 
 import styles from './index.module.scss';

--- a/src/utils/scroll-page.ts
+++ b/src/utils/scroll-page.ts
@@ -1,5 +1,5 @@
-import noop from 'no-op';
 import { gsap } from 'gsap';
+import noop from 'no-op';
 
 interface ScrollProps {
   x: number;


### PR DESCRIPTION
Addding automatic import sort so we don't need to do this manually, if you got eslint and prettier install will sort everything in the order defined in the [eslint config file](https://github.com/Jam3/nextjs-boilerplate/compare/main...feature/automatic-import-sort#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090f), I try to follow the order that we have in our generator right now.

Plugin will also order alphabetically between groups

Open to hear suggestions about proper order, etc