### PR TITLE
feature: register effect gsap

### DIFF
--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import Link from 'next/link';
 import classnames from 'classnames';
 
@@ -17,8 +18,10 @@ const LINKS = [
 }));
 
 function Nav() {
+  const containerRef = useRef<HTMLElement>(null);
+
   return (
-    <nav className={classnames(styles.Nav)}>
+    <nav className={classnames(styles.Nav)} ref={containerRef}>
       <div className={styles.wrapper}>
         <ul className={styles.routes}>
           <a tabIndex={0} aria-label="Skip to content" className={styles.skipToContent} href="#start-of-content">

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,5 +1,6 @@
-import { memo, useRef } from 'react';
+import { memo, useRef, useEffect } from 'react';
 import classnames from 'classnames';
+import gsap from 'gsap';
 
 import styles from './index.module.scss';
 
@@ -11,11 +12,23 @@ type Props = {
 
 function About({ className }: Props) {
   const containerRef = useRef<HTMLElement>(null);
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    const headerElRef = headerRef.current;
+    gsap.effects.fadeIn(headerElRef, { delay: 0.1 });
+
+    return () => {
+      gsap.killTweensOf(headerElRef);
+    };
+  }, []);
 
   return (
     <main className={classnames(styles.About, className)} ref={containerRef}>
       <Head title="About" />
-      <h1 className={styles.title}>About Page</h1>
+      <h1 className={styles.title} ref={headerRef}>
+        About Page
+      </h1>
     </main>
   );
 }

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import classnames from 'classnames';
 import gsap from 'gsap';
 
@@ -12,21 +12,20 @@ type Props = {
 
 function About({ className }: Props) {
   const containerRef = useRef<HTMLElement>(null);
-  const headerRef = useRef<HTMLHeadingElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
-    const headerElRef = headerRef.current;
-    gsap.effects.fadeIn(headerElRef, { delay: 0.1 });
+    const timeline = gsap.timeline().fadeIn(titleRef.current, 0.2);
 
     return () => {
-      gsap.killTweensOf(headerElRef);
+      timeline?.kill();
     };
   }, []);
 
   return (
     <main className={classnames(styles.About, className)} ref={containerRef}>
       <Head title="About" />
-      <h1 className={styles.title} ref={headerRef}>
+      <h1 className={styles.title} ref={titleRef}>
         About Page
       </h1>
     </main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import classnames from 'classnames';
 import gsap from 'gsap';
 
@@ -18,13 +18,13 @@ function Home({ className }: Props) {
 
   useEffect(() => {
     const timeline = gsap
-      .timeline({ delay: 0.1 })
+      .timeline()
       .fadeIn(titleRef.current, 0.2)
       .fadeIn(descriptionRef.current, 0.4)
       .fadeIn(listRef.current?.childNodes, { stagger: 0.1 }, 0.6);
 
     return () => {
-      timeline.kill();
+      timeline?.kill();
     };
   }, []);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { memo, useRef } from 'react';
 import classnames from 'classnames';
+import gsap from 'gsap';
 
 import styles from './index.module.scss';
 
@@ -10,17 +11,34 @@ type Props = {
 };
 
 function Home({ className }: Props) {
-  const containerRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const descriptionRef = useRef<HTMLHeadingElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    const timeline = gsap
+      .timeline({ delay: 0.1 })
+      .fadeIn(titleRef.current, 0.2)
+      .fadeIn(descriptionRef.current, 0.4)
+      .fadeIn(listRef.current?.childNodes, { stagger: 0.1 }, 0.6);
+
+    return () => {
+      timeline.kill();
+    };
+  }, []);
 
   return (
     <main className={classnames(styles.Home, className)} ref={containerRef}>
       <Head />
       <section className={styles.hero}>
-        <h1 className={styles.title}>Welcome to Jam3!</h1>
-        <h2 className={styles.description}>
+        <h1 className={styles.title} ref={titleRef}>
+          Welcome to Jam3!
+        </h1>
+        <h2 className={styles.description} ref={descriptionRef}>
           To get started, edit <code>pages/index.js</code> and save to reload.
         </h2>
-        <ul className={styles.row}>
+        <ul className={styles.row} ref={listRef}>
           <li>
             <a
               href="https://github.com/Jam3?q=&type=source"

--- a/src/utils/gsap-init.ts
+++ b/src/utils/gsap-init.ts
@@ -6,6 +6,21 @@ function gsapInit() {
   gsap.registerPlugin(ScrollToPlugin, ScrollTrigger);
   gsap.defaults({ ease: 'power2.out', duration: 0.333 });
   gsap.config({ nullTargetWarn: false });
+
+  gsap.registerEffect({
+    name: 'fadeIn',
+    extendTimeline: true,
+    effect: (targets: gsap.TweenTarget, config: { duration: number; y: number; delay: number; stagger: number }) => {
+      return gsap.from(targets, {
+        duration: config.duration,
+        autoAlpha: 0,
+        y: config.y,
+        delay: config.delay,
+        stagger: config.stagger
+      });
+    },
+    defaults: { duration: 0.667, y: 20, delay: 0, stagger: 0 }
+  });
 }
 
 export default gsapInit;

--- a/src/utils/gsap-init.ts
+++ b/src/utils/gsap-init.ts
@@ -13,7 +13,7 @@ function gsapInit() {
     effect: (targets: gsap.TweenTarget, config: { duration: number; y: number; delay: number; stagger: number }) => {
       return gsap.from(targets, {
         duration: config.duration,
-        autoAlpha: 0,
+        opacity: 0,
         y: config.y,
         delay: config.delay,
         stagger: config.stagger


### PR DESCRIPTION
Proposal:
- Add a bit of motion as default on our pages, so for example coops have an idea of how we do motion from the beginning (but I could see how this might be too much and is better to keep the generator clean)
- Then probably the most spicy `registerEffect` I think we as a company we should start to use this https://greensock.com/docs/v3/GSAP/gsap.registerEffect() since we repeat ourselves  sometimes a lot in projects when it comes to animation (including me), things like fade from the bottom animations usually in motion bibles are all the same, and registerEffect allows for variations anyway

The not repeating ourselves, is inspired by the Singular Genomics motion bible which had like only 2-3 types of animation repeated everywhere 😆 but I still added `.from autoalpha: 0, y: 50` 100 times

Personally I have only used registerEffect in personal projects and coops projects so I don't have a production example that it works perfect but it should and also the greensock creators talked about this in the presentation that they did here.
