### PR TITLE
chore: small fixes 

### DIFF
--- a/.storybook/main-theme.js
+++ b/.storybook/main-theme.js
@@ -2,10 +2,8 @@ import { create } from '@storybook/theming';
 
 export default create({
   base: 'light',
-
   brandTitle: 'Jam3 NextJS Boilerplate',
   brandUrl: 'https://jam3.com',
-  // TODO: add brandImage - logo
-
+  brandImage: '/favicons/favicon-32x32.png',
   colorSecondary: 'deepskyblue'
 });

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const welcomeStory = '../src/components/storybook/Intro.stories.mdx';
 
 module.exports = {
   core: {
@@ -7,7 +8,7 @@ module.exports = {
   typescript: {
     reactDocgen: false
   },
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  stories: [welcomeStory, '../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: [
     '@storybook/addon-essentials',
     'storybook-jira-addon',

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,12 +1,45 @@
 {
-    "severity": "warning",
-    "extends": "stylelint-config-jam3",
-    "rules": {
-      "block-no-empty": null,
-      "declaration-bang-space-before": null,
-      "declaration-block-trailing-semicolon": "always",
-      "value-list-comma-newline-after": null,
-      "selector-type-no-unknown": null,
-      "selector-type-case": null
-    }
+  "severity": "warning",
+  "extends": "stylelint-config-jam3",
+  "rules": {
+    "block-no-empty": null,
+    "declaration-bang-space-before": null,
+    "declaration-block-trailing-semicolon": "always",
+    "value-list-comma-newline-after": null,
+    "selector-type-no-unknown": null,
+    "selector-type-case": null,
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "keyframes",
+          "mixin",
+          "function",
+          "import",
+          "media",
+          "use",
+          "include",
+          "extend",
+          "font-face",
+          "if",
+          "return",
+          "use"
+        ]
+      }
+    ],
+    "at-rule-allowed-list": [
+      "keyframes",
+      "mixin",
+      "function",
+      "import",
+      "media",
+      "use",
+      "include",
+      "extend",
+      "font-face",
+      "if",
+      "return",
+      "use"
+    ]
   }
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,39 +7,6 @@
     "declaration-block-trailing-semicolon": "always",
     "value-list-comma-newline-after": null,
     "selector-type-no-unknown": null,
-    "selector-type-case": null,
-    "at-rule-no-unknown": [
-      true,
-      {
-        "ignoreAtRules": [
-          "keyframes",
-          "mixin",
-          "function",
-          "import",
-          "media",
-          "use",
-          "include",
-          "extend",
-          "font-face",
-          "if",
-          "return",
-          "use"
-        ]
-      }
-    ],
-    "at-rule-allowed-list": [
-      "keyframes",
-      "mixin",
-      "function",
-      "import",
-      "media",
-      "use",
-      "include",
-      "extend",
-      "font-face",
-      "if",
-      "return",
-      "use"
-    ]
+    "selector-type-case": null
   }
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,7 +22,8 @@ module.exports = {
         'style',
         'test',
         'pxpush',
-        'motion'
+        'motion',
+        'improve'
       ]
     ]
   }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,22 @@ module.exports = {
     'type-enum': [
       2,
       'always',
-      ['build', 'chore', 'ci', 'docs', 'fix', 'feature', 'issue', 'perf', 'refactor', 'revert', 'style', 'test']
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'fix',
+        'feature',
+        'issue',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+        'pxpush',
+        'motion'
+      ]
     ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "storybook-addon-next-router": "3.1.1",
     "storybook-jira-addon": "^2.3.1",
     "stylelint": "13.13.1",
-    "stylelint-config-jam3": "0.1.7",
+    "stylelint-config-jam3": "0.1.8",
     "typescript": "^4.4.3",
     "webp-loader": "0.6.0"
   },

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -3,7 +3,7 @@ import NextHead from 'next/head';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
-import { siteName, siteSlogan } from '@/data/settings';
+import { siteName, siteDescription, siteSlogan, siteKeywords } from '@/data/settings';
 
 type Props = {
   title?: string;
@@ -18,11 +18,7 @@ const ContentSecurityPolicy = dynamic(
   () => import(/* webpackChunkName: "ContentSecurityPolicy" */ './ContentSecurityPolicy')
 );
 
-function Head({
-  title,
-  description = 'Default Description',
-  keywords = ['Jam3', 'Web App', 'React', 'NextJS']
-}: Props) {
+function Head({ title, description = siteDescription, keywords = siteKeywords }: Props) {
   const router = useRouter();
 
   const ogUrl = `${process.env.NEXT_PUBLIC_WEBSITE_SITE_URL}${router.asPath}`;

--- a/src/data/settings.ts
+++ b/src/data/settings.ts
@@ -1,6 +1,8 @@
-// global
-export const resizeDebounceTime = 10; // in ms
+// Global
+export const resizeDebounceTime: number = 10; // in ms
 
-// head
-export const siteName = 'Jam3 Generator';
-export const siteSlogan = 'The Relentless Pursuit of Better';
+// Head
+export const siteName: string = 'Jam3 Generator';
+export const siteDescription: string = 'Default Description';
+export const siteSlogan: string = 'The Relentless Pursuit of Better';
+export const siteKeywords: string[] = ['Jam3', 'Web App', 'React', 'NextJS'];

--- a/src/data/settings.ts
+++ b/src/data/settings.ts
@@ -1,8 +1,8 @@
 // Global
-export const resizeDebounceTime: number = 10; // in ms
+export const resizeDebounceTime = 10; // in ms
 
 // Head
-export const siteName: string = 'Jam3 Generator';
-export const siteDescription: string = 'Default Description';
-export const siteSlogan: string = 'The Relentless Pursuit of Better';
-export const siteKeywords: string[] = ['Jam3', 'Web App', 'React', 'NextJS'];
+export const siteName = 'Jam3 Generator';
+export const siteDescription = 'Default Description';
+export const siteSlogan = 'The Relentless Pursuit of Better';
+export const siteKeywords = ['Jam3', 'Web App', 'React', 'NextJS'];

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -25,7 +25,7 @@
   @if $line-height==normal {
     @return normal;
   }
-  @return $line-height / $font-size;
+  @return math.div($line-height, $font-size);
 }
 
 // Use two pixel values to convert letter-spacing into an em value
@@ -39,7 +39,7 @@
   @if $letter-spacing==normal {
     @return normal;
   }
-  @return #{$letter-spacing / $font-size}em;
+  @return #{math.div($letter-spacing, $font-size)}em;
 }
 
 // Define font-size, line-height and letter-spacing in function

--- a/src/styles/shared.scss
+++ b/src/styles/shared.scss
@@ -3,6 +3,8 @@
 // More information about mixins in:
 // http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins
 
+@use 'sass:math';
+
 @import 'layout';
 @import 'mixins';
 @import 'vars';


### PR DESCRIPTION
By commits:

* [chore: add a welcome story](https://github.com/Jam3/nextjs-boilerplate/commit/e10bdaa0b69ad335b3689e5ff6de89fd4ca39299) - Add a default initial story for when localhost:9001 opens up

* [chore: add brandImage to storybook theme](https://github.com/Jam3/nextjs-boilerplate/commit/563aac792e05e085247747d404f292614d8c55d7) - getting that TODO done this just adds our logo at the top of the page sidebar

* [chore: add pxpush and motion to commitlint](https://github.com/Jam3/nextjs-boilerplate/commit/64ef303ee158da518790b2cc8ebb23258effc3ad) - adding two extra keywords to commitllint that I have used a lot in projects

* [chore: add siteDescription and siteKeywords under settings](https://github.com/Jam3/nextjs-boilerplate/commit/4a9bb5873424dd5a0589f1d57b8de89443f914c0) - add everything to a single place instead of being a default prop string

* [chore: adding sass:math](https://github.com/Jam3/nextjs-boilerplate/pull/205/commits/ad0b96bfa3628fcdfd4da413f944f797574d3213) - adding `sass:math` to fix this warning

<img width="637" alt="Screen Shot 2022-02-09 at 8 17 29 PM" src="https://user-images.githubusercontent.com/14832910/153321643-33058de9-bfd7-4cf7-b0ce-46145b8b2dc6.png">

If this https://github.com/Jam3/stylelint-config-jam3/pull/11 gets approved I will update the stylelint-config npm version instead of overwritting the repo stylelint config


