### PR TITLE
feature: improve gsap.registerEffect to be more TypeScript friendly

### DIFF
--- a/src/utils/gsap-effects.d.ts
+++ b/src/utils/gsap-effects.d.ts
@@ -1,0 +1,35 @@
+/*
+  For every effect that gets registered with GSAP, in order to help TypeScript work with it,
+  we need to add a line within the `EffectsMap` interface, in the following format:
+  `effectName: CallEffect<{ ... effect config types ... }>;`
+*/
+
+declare namespace gsap {
+  interface EffectsMap {
+    fadeIn: CallEffect<{ duration: number; y: number; delay: number; stagger: number }>;
+  }
+
+  /*
+    Things below are just utils to make the above work,
+    ignore them if you're just trying to register a new effect.
+  */
+
+  type CallEffect<Config> = (targets: TweenTarget, config: Partial<Config>) => core.Tween;
+
+  type EffectConfigMap = {
+    [EffectName in keyof EffectsMap as string extends EffectName ? never : EffectName]: Parameters<
+      EffectsMap[EffectName]
+    >[1];
+  };
+
+  type RegisterEffect = (
+    effect: {
+      [EffectName in keyof EffectConfigMap]: {
+        name: EffectName;
+        effect: EffectsMap[EffectName];
+        defaults: Required<EffectConfigMap[EffectName]>;
+        extendTimeline?: boolean;
+      };
+    }[keyof EffectConfigMap]
+  ) => void;
+}

--- a/src/utils/gsap-init.ts
+++ b/src/utils/gsap-init.ts
@@ -2,15 +2,17 @@ import gsap from 'gsap';
 import ScrollToPlugin from 'gsap/dist/ScrollToPlugin';
 import ScrollTrigger from 'gsap/dist/ScrollTrigger';
 
+const registerEffect: gsap.RegisterEffect = gsap.registerEffect;
+
 function gsapInit() {
   gsap.registerPlugin(ScrollToPlugin, ScrollTrigger);
   gsap.defaults({ ease: 'power2.out', duration: 0.333 });
   gsap.config({ nullTargetWarn: false });
 
-  gsap.registerEffect({
+  registerEffect({
     name: 'fadeIn',
     extendTimeline: true,
-    effect: (targets: gsap.TweenTarget, config: { duration: number; y: number; delay: number; stagger: number }) => {
+    effect: (targets, config) => {
       return gsap.from(targets, {
         duration: config.duration,
         opacity: 0,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "types.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "types.d.ts", "src/utils/gsap-effects.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "scripts/templates"]
 }


### PR DESCRIPTION
This will help most significantly in applying effects to provide type checking as well as auto-complete. It will also help with registering the effects on defining required/optional config. The con being ppl adding an effect would need to go to two different files to achieve that...