### PR TITLE
feature: mixins for breakpoints

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,29 +7,6 @@
     "declaration-block-trailing-semicolon": "always",
     "value-list-comma-newline-after": null,
     "selector-type-no-unknown": null,
-    "selector-type-case": null,
-    "at-rule-allowed-list": [
-      "extend",
-      "keyframes",
-      "import",
-      "include",
-      "font-face",
-      "mixin",
-      "function",
-      "return",
-      "if",
-      "else",
-      "media",
-      "page",
-      "content",
-      "use",
-      "error"
-    ],
-    "at-rule-no-unknown": [
-      true,
-      {
-        "ignoreAtRules": ["function", "if", "else", "for", "each", "include", "mixin", "return", "use", "error"]
-      }
-    ]
+    "selector-type-case": null
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,6 +7,29 @@
     "declaration-block-trailing-semicolon": "always",
     "value-list-comma-newline-after": null,
     "selector-type-no-unknown": null,
-    "selector-type-case": null
+    "selector-type-case": null,
+    "at-rule-allowed-list": [
+      "extend",
+      "keyframes",
+      "import",
+      "include",
+      "font-face",
+      "mixin",
+      "function",
+      "return",
+      "if",
+      "else",
+      "media",
+      "page",
+      "content",
+      "use",
+      "error"
+    ],
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["function", "if", "else", "for", "each", "include", "mixin", "return", "use", "error"]
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "default-passive-events": "2.0.0",
         "focus-visible": "5.2.0",
         "get-scroll": "2.0.1",
-        "gsap": "3.8.0",
+        "gsap": "3.9.0",
         "js-cookie": "^3.0.0",
         "next": "^12.0.9",
         "next-pwa": "^5.4.0",
@@ -74,6 +74,7 @@
         "eslint-plugin-promise": "5.1.0",
         "eslint-plugin-react": "7.25.1",
         "eslint-plugin-react-hooks": "4.2.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "husky": "7.0.4",
         "imagemin-gifsicle": "6.0.1",
         "imagemin-mozjpeg": "9.0.0",
@@ -102,7 +103,7 @@
         "storybook-addon-next-router": "3.1.1",
         "storybook-jira-addon": "^2.3.1",
         "stylelint": "13.13.1",
-        "stylelint-config-jam3": "0.1.7",
+        "stylelint-config-jam3": "0.1.9",
         "typescript": "^4.4.3",
         "webp-loader": "0.6.0"
       },
@@ -18996,6 +18997,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -21901,9 +21911,9 @@
       }
     },
     "node_modules/gsap": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.8.0.tgz",
-      "integrity": "sha512-cvpzKkWFePDZCycwXwJnDSpTR3j+a4QLQF/t0c+pXqzRESgAYx5hieaoshzZFjbwsARqr0+5c3GKE7wI273w/g=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.9.0.tgz",
+      "integrity": "sha512-YfIBNHJu4UHES1Vj780+sXtQuiD78QQwgJqktaXE9PO9OuXz5l4ETz05pnhxUfJcxJy4SUINXJxT9ZZhuYwU2g=="
     },
     "node_modules/gulp-header": {
       "version": "1.8.12",
@@ -43494,9 +43504,9 @@
       }
     },
     "node_modules/stylelint-config-jam3": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/stylelint-config-jam3/-/stylelint-config-jam3-0.1.7.tgz",
-      "integrity": "sha512-ej9LqOl3j+NncxUeLIX6KyZy9/ZeXPKfAQitZVyvssirSSgV8pt3HPkpElUwVgmEJRK6uScsxD7wVCV7IrU3DQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/stylelint-config-jam3/-/stylelint-config-jam3-0.1.9.tgz",
+      "integrity": "sha512-qwU/bHW7wU7tpmKVy8/yaqtOrG24sdn4J1OfNo/QXqo5Q/W0oDp1O4oClyBNs6DjcPNV9TFbjvOQ1oxUKoU1ZQ==",
       "dev": true,
       "dependencies": {
         "stylelint-performance-animation": "1.2.2"
@@ -64366,6 +64376,13 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -66549,9 +66566,9 @@
       }
     },
     "gsap": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.8.0.tgz",
-      "integrity": "sha512-cvpzKkWFePDZCycwXwJnDSpTR3j+a4QLQF/t0c+pXqzRESgAYx5hieaoshzZFjbwsARqr0+5c3GKE7wI273w/g=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.9.0.tgz",
+      "integrity": "sha512-YfIBNHJu4UHES1Vj780+sXtQuiD78QQwgJqktaXE9PO9OuXz5l4ETz05pnhxUfJcxJy4SUINXJxT9ZZhuYwU2g=="
     },
     "gulp-header": {
       "version": "1.8.12",
@@ -83552,9 +83569,9 @@
       }
     },
     "stylelint-config-jam3": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/stylelint-config-jam3/-/stylelint-config-jam3-0.1.7.tgz",
-      "integrity": "sha512-ej9LqOl3j+NncxUeLIX6KyZy9/ZeXPKfAQitZVyvssirSSgV8pt3HPkpElUwVgmEJRK6uScsxD7wVCV7IrU3DQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/stylelint-config-jam3/-/stylelint-config-jam3-0.1.9.tgz",
+      "integrity": "sha512-qwU/bHW7wU7tpmKVy8/yaqtOrG24sdn4J1OfNo/QXqo5Q/W0oDp1O4oClyBNs6DjcPNV9TFbjvOQ1oxUKoU1ZQ==",
       "dev": true,
       "requires": {
         "stylelint-performance-animation": "1.2.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "default-passive-events": "2.0.0",
     "focus-visible": "5.2.0",
     "get-scroll": "2.0.1",
-    "gsap": "3.8.0",
+    "gsap": "3.9.0",
     "js-cookie": "^3.0.0",
     "next": "^12.0.9",
     "next-pwa": "^5.4.0",
@@ -137,7 +137,7 @@
     "storybook-addon-next-router": "3.1.1",
     "storybook-jira-addon": "^2.3.1",
     "stylelint": "13.13.1",
-    "stylelint-config-jam3": "0.1.8",
+    "stylelint-config-jam3": "0.1.9",
     "typescript": "^4.4.3",
     "webp-loader": "0.6.0"
   },

--- a/src/components/CookieBanner/CookieBanner.module.scss
+++ b/src/components/CookieBanner/CookieBanner.module.scss
@@ -73,7 +73,7 @@ $cookie-banner-padding: px(20);
     }
   }
 
-  @include breakpoint(tablet) {
+  @include media-tablet {
     button {
       margin-bottom: 0;
     }

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
 
-import { siteName, siteDescription, siteSlogan, siteKeywords } from '@/data/settings';
+import { siteDescription, siteKeywords, siteName, siteSlogan } from '@/data/settings';
 
 type Props = {
   title?: string;

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -12,7 +12,7 @@
   @include flex-center-vert;
   height: $navbar-height-mobile;
 
-  @include breakpoint(desktopSm) {
+  @include media-desktopSm {
     height: $navbar-height-desktop;
   }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -46,7 +46,7 @@ main {
   padding-top: $navbar-height-mobile;
   @include z-index(pages);
 
-  @include breakpoint(desktopSm) {
+  @include media-desktopSm {
     padding-top: $navbar-height-desktop;
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -16,7 +16,7 @@ $layout: (
 ///   }
 @mixin breakpoint($size) {
   @if map-get($layout, $size) {
-    @media (min-width: map-get($layout, $size) + px) {
+    @media (min-width: #{map-get($layout, $size)}px) {
       @content;
     }
   } @else {
@@ -25,7 +25,7 @@ $layout: (
 }
 
 @mixin media-mobile() {
-  @include breakpoint(mobile) {
+  @media (max-width: #{map-get($layout, tablet) - 1}px) {
     @content;
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -3,5 +3,53 @@ $layout: (
   tablet: 768,
   desktopSm: 1024,
   desktopMd: 1440,
-  desktopLg: 1920,
+  desktopLg: 1920
 );
+
+/// Set breakpoint via media queries
+/// @example scss Input
+///   element {
+///     [...phone styles....]
+///     @include breakpoint(tablet) {
+///        [...tablet+desktop styles...]
+///     }
+///   }
+@mixin breakpoint($size) {
+  @if map-get($layout, $size) {
+    @media (min-width: map-get($layout, $size) + px) {
+      @content;
+    }
+  } @else {
+    @error 'Breakpoint not found: ' + $size;
+  }
+}
+
+@mixin media-mobile() {
+  @include breakpoint(mobile) {
+    @content;
+  }
+}
+
+@mixin media-tablet() {
+  @include breakpoint(tablet) {
+    @content;
+  }
+}
+
+@mixin media-desktopSm() {
+  @include breakpoint(desktopSm) {
+    @content;
+  }
+}
+
+@mixin media-desktopMd() {
+  @include breakpoint(desktopMd) {
+    @content;
+  }
+}
+
+@mixin media-desktopLg() {
+  @include breakpoint(desktopLg) {
+    @content;
+  }
+}

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -191,20 +191,6 @@
   z-index: index($elements, $id);
 }
 
-/// Set breakpoint via media queries
-/// @example scss Input
-///   element {
-///     [...phone styles....]
-///     @include breakpoint(tablet) {
-///        [...tablet+desktop styles...]
-///     }
-///   }
-@mixin breakpoint($size) {
-  @media (min-width: #{map-get($layout, $size) + px}) {
-    @content;
-  }
-}
-
 /// Reset button's look
 /// @example scss Input
 ///   button {


### PR DESCRIPTION
* Moved the breakpoints to a single file `layout.scss`
* Added an `@error` in case you enter values that are not in `$layout` for example:

```scss
@include breakpoint(television) {} // this will throw an error now
```


* Create helper mixins for breakpoints to get autocomplete from stylelint and is less prone to errors than actually writing the values in $layout

Using:

```scss
// OLD WAY - but you can still use it if your prefer
@include breakpoint(tablet) {}

// NEW WAY
@include media-tablet {}
```

---

If you want to play around with this change

Here is a sass playground https://www.sassmeister.com/gist/7db97d8c46dbec83dee2368e3fa71353