### PR TITLE
fix: suppress console in production build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,6 +47,9 @@ const nextJSConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'src/styles')]
   },
+  experimental: {
+    removeConsole: process.env.NEXT_PUBLIC_ENVIRONMENT === 'production'
+  },
   webpack: function (config, options) {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- JIRA Ticket Link -->
Jira Ticket ID: <JIRA Ticket ID> <!--- Example: JRA-34 -->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
From time to time, developers forget to remove debugging code such as `console.log`, `console.warn`, and more. 

## Solution Description
At the build process, NextJS will suppress all `console` so that it makes more production ready. 

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
