### PR TITLE
[BUG] Cache Invalidation for Git Flow Workflow

### DIFF
--- a/.circleci/workflows/git-flow-based.yml
+++ b/.circleci/workflows/git-flow-based.yml
@@ -46,6 +46,20 @@ workflows:
             - slack-notification-onsuccess-deployment:
                 environment: 'Develop'
                 slack_channel: $SLACK_CHANNEL_ID
+      - cache-invalidation:
+          name: cache-invalidation-develop
+          context: SLACK_CREDENTIALS
+          requires:
+            - deployment-develop
+          env_suffix: '_DEV'
+          post-steps:
+            - slack-notification-onfail:
+                environment: 'Develop'
+                slack_channel: $SLACK_CHANNEL_ID
+                error_message: 'Cache Invalidation Failed'
+            - slack-notification-onsuccess-deployment:
+                environment: 'Develop'
+                slack_channel: $SLACK_CHANNEL_ID
       - deployment:
           name: deployment-staging
           requires:
@@ -64,6 +78,20 @@ workflows:
             - slack-notification-onsuccess-deployment:
                 environment: 'Staging'
                 slack_channel: $SLACK_CHANNEL_ID
+      - cache-invalidation:
+          name: cache-invalidation-staging
+          context: SLACK_CREDENTIALS
+          requires:
+            - deployment-staging
+          env_suffix: '_STAGE'
+          post-steps:
+            - slack-notification-onfail:
+                environment: 'Staging'
+                slack_channel: $SLACK_CHANNEL_ID
+                error_message: 'Cache Invalidation Failed'
+            - slack-notification-onsuccess-deployment:
+                environment: 'Staging'
+                slack_channel: $SLACK_CHANNEL_ID
       - deployment:
           name: deployment-production
           requires:
@@ -79,6 +107,20 @@ workflows:
                 environment: 'Production'
                 slack_channel: $SLACK_CHANNEL_ID
                 error_message: 'Deployment Fail'
+            - slack-notification-onsuccess-deployment:
+                environment: 'Production'
+                slack_channel: $SLACK_CHANNEL_ID
+      - cache-invalidation:
+          name: cache-invalidation-production
+          context: SLACK_CREDENTIALS
+          requires:
+            - deployment-production
+          env_suffix: '_PROD'
+          post-steps:
+            - slack-notification-onfail:
+                environment: 'Production'
+                slack_channel: $SLACK_CHANNEL_ID
+                error_message: 'Cache Invalidation Failed'
             - slack-notification-onsuccess-deployment:
                 environment: 'Production'
                 slack_channel: $SLACK_CHANNEL_ID


### PR DESCRIPTION
Noticed this in my project (using git flow). Cache wasn't invalidating and taking a long time for changes to reflect on environment after successful deploy. Cloudfront had no invalidation. Simply copy and pasted the invalidation step from trunk based workflow to the git flow one.
