### PR TITLE
BaseButton component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "plugin:import/typescript",
     "prettier",
     "plugin:prettier/recommended",
-    "plugin:sonarjs/recommended"
+    "plugin:sonarjs/recommended",
+    "plugin:storybook/recommended"
   ],
   "plugins": ["jam3", "simple-import-sort", "sonarjs", "promise"],
   "parser": "@typescript-eslint/parser",
@@ -30,13 +31,14 @@
     }
   },
   "rules": {
+    "jsx-a11y/anchor-has-content": "off",
+    "jsx-a11y/heading-has-content": "off",
     "import/no-webpack-loader-syntax": "off",
     "import/no-anonymous-default-export": "off",
     "import/no-unresolved": ["error", { "ignore": ["svg-inline-loader"] }],
     "import/named": "error",
     "import/default": "error",
     "import/first": "error",
-    "import/order": ["error", { "groups": ["builtin", "external", ["parent", "sibling", "index"]] }],
     "import/no-extraneous-dependencies": [
       "warn",
       { "devDependencies": true, "optionalDependencies": true, "peerDependencies": false }
@@ -48,11 +50,14 @@
         "groups": [
           ["^react", "^next", "^@jam3", "^@?\\w", "^\\u0000"], // our stack & ext library & side effect
           ["^.+\\.scss$", "^@/styles/.+\\.scss$"], // css & scss
-          ["^@/data"], // data
-          ["^@/pages", "^@/components"], // components
-          ["^@/services", "^@/hooks", "^@/utils"], // utils
-          ["^@/redux"], // redux
-          ["^@/components/svgs", "^@/data", "^@/assets"], // data
+          ["^@/data", "^@/redux"], // data
+          ["^@/services"],
+          ["^@/utils"],
+          ["^@/hooks"],
+          ["^@/components/Layout, ^@/components/Page", "^@/components/Screen"], // containers
+          ["^@/components"], // components
+          ["^@/svgs"], // svgs
+          ["^@/assets"], // assets
           ["^@/"], // other basePaths
           ["^"] // rest
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "eslint-plugin-sonarjs": "^0.13.0",
+        "eslint-plugin-storybook": "^0.6.4",
         "husky": "7.0.4",
         "lint-staged": "12.0.3",
         "next-sitemap": "^3.0.5",
@@ -20942,6 +20943,33 @@
       },
       "peerDependencies": {
         "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-storybook": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.6.tgz",
+      "integrity": "sha512-nqYq802vJABpaV0n9cpIZl4Mlmy1yStxa8T3sPqvqbByOpXXtA9ZKRqVv2faSDp0DKVC0B3ItTNU7iMX3Et8VQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.0.1",
+        "@typescript-eslint/experimental-utils": "^5.3.0",
+        "requireindex": "^1.1.0",
+        "ts-dedent": "^2.2.0"
+      },
+      "engines": {
+        "node": "12.x || 14.x || >= 16"
+      },
+      "peerDependencies": {
+        "eslint": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@storybook/csf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -62255,6 +62283,29 @@
       "integrity": "sha512-t3m7ta0EspzDxSOZh3cEOJIJVZgN/TlJYaBGnQlK6W/PZNbWep8q4RQskkJkA7/zwNpX0BaoEOSUUrqaADVoqA==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-storybook": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.6.tgz",
+      "integrity": "sha512-nqYq802vJABpaV0n9cpIZl4Mlmy1yStxa8T3sPqvqbByOpXXtA9ZKRqVv2faSDp0DKVC0B3ItTNU7iMX3Et8VQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/csf": "^0.0.1",
+        "@typescript-eslint/experimental-utils": "^5.3.0",
+        "requireindex": "^1.1.0",
+        "ts-dedent": "^2.2.0"
+      },
+      "dependencies": {
+        "@storybook/csf": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+          "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.15"
+          }
+        }
+      }
     },
     "eslint-plugin-testing-library": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-sonarjs": "^0.13.0",
+    "eslint-plugin-storybook": "^0.6.4",
     "husky": "7.0.4",
     "lint-staged": "12.0.3",
     "next-videos": "^1.4.0",

--- a/src/components/BaseButton/BaseButton.stories.tsx
+++ b/src/components/BaseButton/BaseButton.stories.tsx
@@ -1,0 +1,23 @@
+import { Story } from '@storybook/react';
+
+import BaseButton, { BaseButtonProps } from './BaseButton';
+
+export default { title: 'components/BaseButton' };
+
+export const Button: Story<BaseButtonProps> = (args) => (
+  <BaseButton {...args}>
+    <span>I&apos;m a button since I don&apos;t have an href prop</span>
+  </BaseButton>
+);
+
+export const Link: Story<BaseButtonProps> = (args) => (
+  <BaseButton {...args} href="/">
+    I&apos;m a link cause I have an href prop!
+    <br />
+    Next.js routing navigation
+    <br />
+    will happen automatically.
+    <br />
+    If the href starts with &quot;/&quot;.
+  </BaseButton>
+);

--- a/src/components/BaseButton/BaseButton.tsx
+++ b/src/components/BaseButton/BaseButton.tsx
@@ -1,0 +1,131 @@
+import {
+  FocusEvent,
+  forwardRef,
+  KeyboardEvent,
+  memo,
+  MouseEvent,
+  ReactNode,
+  Ref,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import Link from 'next/link';
+import classNames from 'classnames';
+import { UrlObject } from 'url';
+
+import isRoutedHref from '@/utils/is-routed-href';
+export interface BaseButtonProps {
+  children: ReactNode;
+  playSound?: boolean;
+  className?: string;
+  download?: boolean;
+  disabled?: boolean;
+  tabIndex?: number;
+  subject?: string;
+  target?: string;
+  title?: string;
+  href?: string | UrlObject;
+  role?: string;
+  rel?: string;
+  id?: string;
+  type?: 'submit' | 'reset' | 'button';
+  onClick?: (event?: MouseEvent<HTMLElement>) => void;
+  onFocus?: (event?: FocusEvent<HTMLElement>) => void;
+  onKeyDown?: (event?: KeyboardEvent<HTMLElement>) => void;
+  onMouseEnter?: (event?: MouseEvent<HTMLElement>) => void;
+  onMouseLeave?: (event?: MouseEvent<HTMLElement>) => void;
+  'aria-label'?: string;
+}
+
+// Controller (handles global state, router, data fetching, etc. Feeds props to the view component)
+const BaseButton = forwardRef<HTMLElement, BaseButtonProps>(
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  ({ className, href, subject, children, disabled, playSound, onClick, ...props }, ref) => {
+    const [url, setUrl] = useState<string | UrlObject | undefined>(href);
+
+    const pathname = useMemo(() => (typeof href === 'string' ? href : href?.pathname || ''), [href]);
+    const routed = useMemo(() => isRoutedHref(href, props.download), [href, props.download]);
+
+    let prefix = '';
+    let suffix = '';
+
+    if (href && !props.download) {
+      if (/^(https:\/\/|http:\/\/)/.test(pathname)) {
+        props.target = '_blank';
+        props.rel = 'noopener noreferrer';
+      } else if (pathname.includes('@')) {
+        props.target = '_blank';
+        prefix = 'mailto:';
+        if (subject) suffix = `?subject=${subject}`;
+      }
+    }
+
+    const handleClick = useCallback(
+      (e: MouseEvent<HTMLElement>) => {
+        onClick?.(e);
+        // Add analytics, soundfx, etc... here
+      },
+      [onClick]
+    );
+
+    useEffect(() => {
+      if (href && routed) {
+        setUrl(() => {
+          if (typeof href === 'string') {
+            if (href.startsWith('#')) return href;
+            return {
+              pathname: `${href.split('#')[0].split('?')[0]}`,
+              hash: href.split('#')[1] || '',
+              query: (href.split('#')[0].split('?')[1] || '').replace('?', '')
+            };
+          }
+          return {
+            ...href,
+            pathname: `${href.pathname}`
+          };
+        });
+      }
+    }, [href, pathname, routed]);
+
+    return href ? (
+      routed ? (
+        <Link href={url as UrlObject} scroll={false}>
+          <a
+            ref={ref as Ref<HTMLAnchorElement>}
+            className={classNames('BaseButton', className)}
+            onClick={handleClick}
+            {...props}
+          >
+            {children}
+          </a>
+        </Link>
+      ) : (
+        <a
+          ref={ref as Ref<HTMLAnchorElement>}
+          className={className}
+          href={`${prefix}${href}${suffix}`}
+          {...props}
+          onClick={handleClick}
+        >
+          {children}
+        </a>
+      )
+    ) : (
+      <button
+        ref={ref as Ref<HTMLButtonElement>}
+        className={className}
+        disabled={disabled}
+        onClick={handleClick}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+BaseButton.displayName = 'BaseButton';
+
+export default memo(BaseButton);

--- a/src/components/BaseImage/BaseImage.tsx
+++ b/src/components/BaseImage/BaseImage.tsx
@@ -5,8 +5,9 @@ import noop from 'no-op';
 
 import css from './BaseImage.module.scss';
 
-import useCombinedRefs from '@/hooks/use-combined-refs';
 import getOptimizedImageURL, { OptmizedImageEdits } from '@/utils/get-optimized-image-url';
+
+import useCombinedRefs from '@/hooks/use-combined-refs';
 
 export interface BaseImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   // supports both src (for public images) or data (for imported images)

--- a/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -1,5 +1,7 @@
 import { Story } from '@storybook/react';
 
+import BaseButton from '@/components/BaseButton/BaseButton';
+
 import CookieBanner, { CookieBannerProps } from './CookieBanner';
 
 export default { title: 'components/CookieBanner' };
@@ -16,9 +18,9 @@ Default.argTypes = {};
 export const WithChildren: Story<CookieBannerProps> = (args) => (
   <CookieBanner {...args}>
     We use cookies on this website to improve your experience. Learn more on our{' '}
-    <a href="https://www.jam3.com/privacy" target="_blank'">
+    <BaseButton href="https://www.jam3.com/privacy" target="_blank'">
       Privacy Policy
-    </a>
+    </BaseButton>
     .
   </CookieBanner>
 );

--- a/src/components/CookieBanner/CookieBanner.tsx
+++ b/src/components/CookieBanner/CookieBanner.tsx
@@ -4,6 +4,8 @@ import noop from 'no-op';
 
 import css from './CookieBanner.module.scss';
 
+import BaseButton from '@/components/BaseButton/BaseButton';
+
 const copy = {
   settings: 'Cookie Settings',
   close: 'close',
@@ -88,16 +90,16 @@ const CookieBanner: FC<CookieBannerProps> = ({
       <p className={css.description}>{children || defaultText}</p>
 
       <div className={css.buttonContainer}>
-        <button onClick={handleAcceptAllCookies}>{acceptCta}</button>
-        <button onClick={handleDeclineAllCookies}>{rejectCta}</button>
-        <button onClick={handleCookieSettingsClick}>{copy.settings}</button>
+        <BaseButton onClick={handleAcceptAllCookies}>{acceptCta}</BaseButton>
+        <BaseButton onClick={handleDeclineAllCookies}>{rejectCta}</BaseButton>
+        <BaseButton onClick={handleCookieSettingsClick}>{copy.settings}</BaseButton>
       </div>
 
       {showCookieSetting && (
         <div className={css.cookieSettings}>
-          <button className={css.cookieSettingsClose} onClick={handleCookieSettingsClose}>
+          <BaseButton className={css.cookieSettingsClose} onClick={handleCookieSettingsClose}>
             {copy.close}
-          </button>
+          </BaseButton>
 
           <div className={css.cookieSettingsContent}>
             <p className={css.cookieSettingsDescription}>{copy.description}</p>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,11 @@
 import { FC, memo } from 'react';
-import Link from 'next/link';
 import classNames from 'classnames';
 
 import css from './Footer.module.scss';
 
 import routes from '@/data/routes';
+
+import BaseButton from '@/components/BaseButton/BaseButton';
 
 export interface FooterProps {
   className?: string;
@@ -16,9 +17,9 @@ const Footer: FC<FooterProps> = ({ className }) => {
       <ul>
         {Object.values(routes).map(({ path, title }) => (
           <li key={path}>
-            <Link href={path}>
+            <BaseButton href={path}>
               <a>{title}</a>
-            </Link>
+            </BaseButton>
           </li>
         ))}
       </ul>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,16 +5,16 @@ import { useRouter } from 'next/router';
 import { device } from '@jam3/detect';
 
 import { PageProps } from '@/data/types';
+import { setIsWebpSupported, setPrevRoute, useAppDispatch } from '@/redux';
+
+import { GtmScript } from '@/utils/analytics';
+import { checkWebpSupport } from '@/utils/basic-functions';
+
+import { useCookieBanner } from '@/hooks';
 
 import Footer from '@/components/Footer/Footer';
 import Head from '@/components/Head/Head';
 import Nav from '@/components/Nav/Nav';
-
-import { useCookieBanner } from '@/hooks';
-import { GtmScript } from '@/utils/analytics';
-import { checkWebpSupport } from '@/utils/basic-functions';
-
-import { setIsWebpSupported, setPrevRoute, useAppDispatch } from '@/redux';
 
 const RotateScreen = dynamic(() => import('@/components/RotateScreen/RotateScreen'), { ssr: false });
 const CookieBanner = dynamic(() => import('@/components/CookieBanner/CookieBanner'), { ssr: false });

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,13 +1,12 @@
 import { FC } from 'react';
-import Link from 'next/link';
 import classNames from 'classnames';
 
 import css from './Nav.module.scss';
 
 import routes from '@/data/routes';
 
+import BaseButton from '@/components/BaseButton/BaseButton';
 import BaseImage from '@/components/BaseImage/BaseImage';
-
 import SvgThreeLogo from '@/components/svgs/three-logo.svg';
 
 const LINKS = [
@@ -32,18 +31,16 @@ const Nav: FC<NavProps> = ({ className }) => {
           </a>
           {Object.values(routes).map(({ path, title }) => (
             <li key={path}>
-              <Link href={path}>
-                <a aria-label="Home">{path === '/' ? <SvgThreeLogo className={css.threeLogo} /> : title}</a>
-              </Link>
+              <BaseButton href={path}>{path === '/' ? <SvgThreeLogo className={css.threeLogo} /> : title}</BaseButton>
             </li>
           ))}
         </ul>
         <ul className={css.links}>
           {LINKS.map(({ key, href, label, data }) => (
             <li key={key}>
-              <a href={href} target="_blank" rel="noopener noreferrer" aria-label={label}>
+              <BaseButton href={href} aria-label={label}>
                 <BaseImage data={data} alt={label} />
-              </a>
+              </BaseButton>
             </li>
           ))}
         </ul>

--- a/src/components/PageHome/PageHome.tsx
+++ b/src/components/PageHome/PageHome.tsx
@@ -6,6 +6,8 @@ import css from './PageHome.module.scss';
 
 import { PageProps } from '@/data/types';
 
+import BaseButton from '@/components/BaseButton/BaseButton';
+
 export interface PageHomeProps extends PageProps {
   className?: string;
 }
@@ -38,21 +40,16 @@ const PageHome: FC<PageHomeProps> = ({ className }) => {
         </h2>
         <ul className={css.row} ref={listRef}>
           <li>
-            <a
-              href="https://github.com/Jam3?q=&type=source"
-              className={css.card}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <BaseButton href="https://github.com/Jam3?q=&type=source" className={css.card}>
               <h3>Visit out GitHub</h3>
               <p>See our contributions to Open Source community</p>
-            </a>
+            </BaseButton>
           </li>
           <li>
-            <a href="https://jam3.dev" className={css.card} target="_blank" rel="noopener noreferrer">
+            <BaseButton href="https://jam3.dev" className={css.card}>
               <h3>Jam3.dev</h3>
               <p>Learn more about Jam3.dev</p>
-            </a>
+            </BaseButton>
           </li>
         </ul>
       </section>

--- a/src/hooks/use-layout.ts
+++ b/src/hooks/use-layout.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { useWindowSize } from '@/hooks';
 import layout, { Breakpoints } from '@/utils/layout';
+
+import { useWindowSize } from '@/hooks';
 
 /**
  * Layout hook

--- a/src/hooks/use-low-power-mode.ts
+++ b/src/hooks/use-low-power-mode.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { os } from '@jam3/detect';
 
 import visibility from '@/services/visibility';
+
 import getLowPowerMode from '@/utils/detect-low-power-mode';
 
 let cachedResult = false;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,13 +7,12 @@ import '@/utils/why-did-you-render';
 import '@/styles/global.scss';
 
 import { PageProps } from '@/data/types';
-
-import Layout from '@/components/Layout/Layout';
+import { store } from '@/redux';
 
 import gsapInit from '@/utils/gsap-init';
 import setBodyClasses from '@/utils/set-body-classes';
 
-import { store } from '@/redux';
+import Layout from '@/components/Layout/Layout';
 
 require('default-passive-events');
 require('focus-visible');

--- a/src/utils/is-routed-href.ts
+++ b/src/utils/is-routed-href.ts
@@ -1,0 +1,9 @@
+import { UrlObject } from 'url';
+
+function isRoutedHref(href?: string | UrlObject, download = false) {
+  if (!href) return false;
+  const pathname = typeof href === 'string' ? href : href?.pathname || '';
+  return (pathname?.startsWith('#') || pathname?.startsWith('/')) && !download;
+}
+
+export default isRoutedHref;


### PR DESCRIPTION
This PR introduces the BaseButton component, an abstraction layer for all links and buttons of a project. By using this component for every link and button, we gain global control and become able to manage shared behavior quickly and easily globally. For instance, if we need to play a sound for all buttons on the website, trigger analytics events, etc... we can do it by extending this component.

This component also:
- Detects when an href prop is a local link and uses the `next/link` automatically to dispatch route changes.
- Automatically uses the HTML button element if no href is set.
- If it receives an href link to an external page, it automatically adds `target="_blank"` and `rel="noopener noreferrer"` to the anchor element.