### PR TITLE
Update webpack.js

### DIFF
--- a/.storybook/webpack.js
+++ b/.storybook/webpack.js
@@ -3,7 +3,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 const introPath = path.resolve(__dirname, './intro');
-const svgsPath = path.resolve(__dirname, '../src/components/svgs');
 const srcPath = path.resolve(__dirname, '../src');
 
 module.exports.webpackFinal = async (config) => {
@@ -13,7 +12,7 @@ module.exports.webpackFinal = async (config) => {
   sassRule.exclude = [introPath];
 
   const imageRule = config.module.rules.find((rule) => rule.test.test('.svg'));
-  imageRule.exclude = [svgsPath];
+  imageRule.exclude = /\.svg$/;
 
   config.module.rules.push(
     {
@@ -28,7 +27,7 @@ module.exports.webpackFinal = async (config) => {
         }
       ]
     },
-    { test: /\.svg$/, include: svgsPath, use: [{ loader: '@svgr/webpack' }] }
+    { test: /\.svg$/, use: [{ loader: '@svgr/webpack' }] }
   );
 
   config.plugins.push(new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }));


### PR DESCRIPTION
We can make it simple and eliminate SVG path while only care about the extension.
This will allow injecting SVG as code from any folder and not stick to `components/svgs` for that.
This how our next config is set up without excluding `components/svgs` path and simply looking at the extension