### PR TITLE
Storybook update

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import { Provider } from 'react-redux';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
 
 import '../src/styles/global.scss';
 
@@ -10,6 +11,11 @@ gsapInit();
 setBodyClasses();
 
 export const decorators = [
+  (Story) => {
+    require('default-passive-events');
+    require('focus-visible');
+    return Story();
+  },
   (Story) => (
     <Provider store={store}>
       <Story />
@@ -80,5 +86,8 @@ export const parameters = {
         type: 'tablet'
       }
     }
+  },
+  nextRouter: {
+    Provider: RouterContext.Provider
   }
 };

--- a/.storybook/webpack.js
+++ b/.storybook/webpack.js
@@ -3,7 +3,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 const introPath = path.resolve(__dirname, './intro');
-const svgsPath = path.resolve(__dirname, '../src/components/svgs');
 const srcPath = path.resolve(__dirname, '../src');
 
 module.exports.webpackFinal = async (config) => {
@@ -13,7 +12,7 @@ module.exports.webpackFinal = async (config) => {
   sassRule.exclude = [introPath];
 
   const imageRule = config.module.rules.find((rule) => rule.test.test('.svg'));
-  imageRule.exclude = [svgsPath];
+  imageRule.exclude = /\.svg$/;
 
   config.module.rules.push(
     {
@@ -28,7 +27,7 @@ module.exports.webpackFinal = async (config) => {
         }
       ]
     },
-    { test: /\.svg$/, include: svgsPath, use: [{ loader: '@svgr/webpack' }] }
+    { test: /\.svg$/, use: [{ loader: '@svgr/webpack' }] }
   );
 
   config.plugins.push(new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }));


### PR DESCRIPTION
* **update Preview:**  decorators and parameters to match Nextjs app setup
* **update Webpack:** We can make it simple and eliminate the SVG path and only care about the extension.
This will allow injecting SVG as code from any folder and not stick to `components/svgs` this can be handy esp when bringing things from React UI library where icons can be contained within a component folder e.g VideoPlayer 
This is how our next webpack config is set up as well without specifying `components/svgs` path and simply looking at the SVG extension
 